### PR TITLE
Update EFI file structure to reflect updates to AppleSupportPkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ To setup OpenCore’s folder structure, copy the files from OpenCorePkg so your 
    |   |   |--Drivers
    |   |   |   |--ApfsDriverLoader.efi
    |   |   |   |--AppleGenericInput.efi
-   |   |   |   |--AppleUiSupport.efi
    |   |   |   |--FWRuntimeServices.efi
    |   |   |   |--UsbKbDxe.efi
    |   |   |   |--VBoxHfs.efi
@@ -96,7 +95,6 @@ To setup OpenCore’s folder structure, copy the files from OpenCorePkg so your 
    |   |   |   |--WhateverGreen.kext
    |   |   |--OpenCore.efi
    |   |   |--Tools
-   |   |   |   |--CleanNvram.efi
    |   |   |   |--Shell.efi
    |   |   |   |--VerifyMsrE2.efi
 


### PR DESCRIPTION
Per the AppleSupportPkg documentation for the 2.1.0 release (https://github.com/acidanthera/AppleSupportPkg/releases/tag/2.1.0), both AppleUiSupport and CleanNvram have been moved into OpenCore mainline. 

This pull request updates the expected EFI file structure to reflect these updates.